### PR TITLE
Update requirements.txt: configobj protocol

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Dependencies
 
 # Requirements for validate
-git+git://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
+git+https://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
 jsonschema==3.1
 


### PR DESCRIPTION
Protocol to download configobj in requirements.txt needs to be updated.
See failure in PR nvaccess/addon-datastore#38


Use HTTPS for configObj requirement
This matches what is now done in NVDA.
Stop using legacy `git` protocol when downloading configobj from GitHub (nvaccess/nvda#13018)
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

>GitHub is in the process of disabling the old git:// protocol.
>Currently the url to configObj in our requirements file is using it making it impossible to install the dependency from the repository.