### PR TITLE
Ensure manifest matches last tested and min NVDA versions

### DIFF
--- a/_tests/test_createJson.py
+++ b/_tests/test_createJson.py
@@ -81,38 +81,6 @@ class IntegrationTestCreateJson(unittest.TestCase):
 		self.assertDictEqual(actualJson, expectedJson)
 
 
-class Test_getVersionNumber(unittest.TestCase):
-	def test_tripleDigitVersion_isValid(self):
-		""" Canonical version (major, minor, patch) expected.
-		"""
-		versionNumber = createJson.getVersionNumber("1.2.3")
-		self.assertEqual(versionNumber.major, 1)
-		self.assertEqual(versionNumber.minor, 2)
-		self.assertEqual(versionNumber.patch, 3)
-
-	def test_doubleDigitVersion_isValid(self):
-		"""patch is optional, assumed to be zero.
-		"""
-		versionNumber = createJson.getVersionNumber("1.02")
-		self.assertEqual(versionNumber.major, 1)
-		self.assertEqual(versionNumber.minor, 2)
-		self.assertEqual(versionNumber.patch, 0)
-
-	def test_singleDigitVersion_raises(self):
-		with self.assertRaises(ValueError, msg="Single digit version numbers are expected to be an error."):
-			createJson.getVersionNumber("1")
-
-	def test_tooManyValues_raises(self):
-		with self.assertRaises(ValueError, msg="More than three parts is expected as an error."):
-			createJson.getVersionNumber("1.2.3.4")
-
-	def test_versionWithNonDigit(self):
-		with self.assertRaises(
-			ValueError,
-			msg="Non-digit chars in version number expected as an error."):
-			createJson.getVersionNumber("1.2.3a")
-
-
 class Test_buildOutputFilePath(unittest.TestCase):
 	def setUp(self) -> None:
 		self.outputDir = os.path.join(OUTPUT_DATA_PATH, "test_buildOutputFilePath")

--- a/_tests/test_majorMinorPatch.py
+++ b/_tests/test_majorMinorPatch.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2022-2023 Noelia Ruiz Martínez, NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import unittest
+
+from _validate.majorMinorPatch import MajorMinorPatch
+
+
+class Test_getVersionNumber(unittest.TestCase):
+	def test_tripleDigitVersion_isValid(self):
+		""" Canonical version (major, minor, patch) expected.
+		"""
+		versionNumber = MajorMinorPatch.getFromStr("1.2.3")
+		self.assertEqual(versionNumber.major, 1)
+		self.assertEqual(versionNumber.minor, 2)
+		self.assertEqual(versionNumber.patch, 3)
+
+	def test_doubleDigitVersion_isValid(self):
+		"""patch is optional, assumed to be zero.
+		"""
+		versionNumber = MajorMinorPatch.getFromStr("1.02")
+		self.assertEqual(versionNumber.major, 1)
+		self.assertEqual(versionNumber.minor, 2)
+		self.assertEqual(versionNumber.patch, 0)
+
+	def test_singleDigitVersion_raises(self):
+		with self.assertRaises(ValueError, msg="Single digit version numbers are expected to be an error."):
+			MajorMinorPatch.getFromStr("1")
+
+	def test_tooManyValues_raises(self):
+		with self.assertRaises(ValueError, msg="More than three parts is expected as an error."):
+			MajorMinorPatch.getFromStr("1.2.3.4")
+
+	def test_versionWithNonDigit(self):
+		with self.assertRaises(
+			ValueError,
+			msg="Non-digit chars in version number expected as an error."):
+			MajorMinorPatch.getFromStr("1.2.3a")

--- a/_tests/test_validate.py
+++ b/_tests/test_validate.py
@@ -400,6 +400,69 @@ class validate_checkMinRequiredVersionExists(unittest.TestCase):
 		)
 
 
+class Validate_checkMinNVDAVersionMatches(unittest.TestCase):
+	"""Tests for the checkMinNVDAVersionMatches function.
+	"""
+	def setUp(self):
+		self.submissionData = getValidAddonSubmission()
+		self.manifest = getAddonManifest()
+
+	def tearDown(self):
+		self.submissionData = None
+		self.manifest = None
+
+	def test_valid(self):
+		errors = list(
+			validate.checkMinNVDAVersionMatches(self.manifest, self.submissionData)
+		)
+		self.assertEqual(errors, [])
+
+	def test_invalid(self):
+		self.manifest["minimumNVDAVersion"] = "1999.1.0"
+		errors = list(
+			validate.checkMinNVDAVersionMatches(self.manifest, self.submissionData)
+		)
+		self.assertEqual(
+			errors,
+			[
+				"Submission data 'minNVDAVersion' field does not match 'minNVDAVersion' field "
+				'in addon manifest: 1999.1.0 vs minNVDAVersion: 2022.1.0'
+			]
+		)
+
+
+class Validate_checkLastTestedNVDAVersionMatches(unittest.TestCase):
+	"""Tests for the checkLastTestedNVDAVersionMatches function.
+	"""
+	def setUp(self):
+		self.submissionData = getValidAddonSubmission()
+		self.manifest = getAddonManifest()
+
+	def tearDown(self):
+		self.submissionData = None
+		self.manifest = None
+
+	def test_valid(self):
+		errors = list(
+			validate.checkLastTestedNVDAVersionMatches(self.manifest, self.submissionData)
+		)
+		self.assertEqual(errors, [])
+
+	def test_invalid(self):
+		self.manifest["lastTestedNVDAVersion"] = "9999.1.0"
+		errors = list(
+			validate.checkLastTestedNVDAVersionMatches(self.manifest, self.submissionData)
+		)
+		self.assertEqual(
+			errors,
+			[
+				"Submission data 'lastTestedVersion' field does not match "
+				"'lastTestedNVDAVersion' field in addon manifest: 9999.1.0 vs "
+				'lastTestedVersion: 2023.1.0'
+			]
+		)
+
+
 class Validate_checkVersions(unittest.TestCase):
 	"""Tests for the checkVersions function.
 
@@ -424,10 +487,6 @@ class Validate_checkVersions(unittest.TestCase):
 	def tearDown(self):
 		self.submissionData = None
 		self.manifest = None
-
-	@staticmethod
-	def _getVersionString(version: VersionNumber):
-		return f"{version.major}.{version.minor}.{version.patch}"
 
 	def _setupVersions(
 			self,

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2022 Noelia Ruiz Martínez, NV Access Limited
+# Copyright (C) 2022-2023 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 import dataclasses
 import json
 import argparse
-from dataclasses import dataclass
 import os
 import sys
 
 import typing
+from .majorMinorPatch import MajorMinorPatch
 
 sys.path.append(os.path.dirname(__file__))  # To allow this module to be run as a script by runcreatejson.bat
 # E402 module level import not at top of file
@@ -20,30 +20,10 @@ import sha256  # noqa:E402
 del sys.path[-1]
 
 
-@dataclass
-class Version:
-	major: int = 0
-	minor: int = 0
-	patch: int = 0
-
-
 def getSha256(addonPath: str) -> str:
 	with open(addonPath, "rb") as f:
 		sha256Addon = sha256.sha256_checksum(f)
 	return sha256Addon
-
-
-def getVersionNumber(ver: str) -> Version:
-	verParts = ver.split(".")
-	verLen = len(verParts)
-	if verLen < 2 or verLen > 3:
-		raise ValueError(f"Version not valid: {ver}")
-	version = Version(
-		major=int(verParts[0]),
-		minor=int(verParts[1]),
-		patch=0 if len(verParts) == 2 else int(verParts[2])
-	)
-	return version
 
 
 def generateJsonFile(
@@ -77,7 +57,7 @@ def generateJsonFile(
 
 def buildOutputFilePath(data, parentDir) -> os.PathLike:
 	addonDir = os.path.join(parentDir, data["addonId"])
-	versionNumber = Version(**data["addonVersionNumber"])
+	versionNumber = MajorMinorPatch(**data["addonVersionNumber"])
 	canonicalVersionString = ".".join(
 		(str(i) for i in dataclasses.astuple(versionNumber))
 	)
@@ -107,13 +87,13 @@ def _createDictMatchingJsonSchema(
 		"homepage": manifest.get("url"),
 		"addonVersionName": manifest["version"],
 		"addonVersionNumber": dataclasses.asdict(
-			getVersionNumber(manifest["version"])
+			MajorMinorPatch.getFromStr(manifest["version"])
 		),
 		"minNVDAVersion": dataclasses.asdict(
-			getVersionNumber(manifest["minimumNVDAVersion"])
+			MajorMinorPatch.getFromStr(manifest["minimumNVDAVersion"])
 		),
 		"lastTestedVersion": dataclasses.asdict(
-			getVersionNumber(manifest["lastTestedNVDAVersion"])
+			MajorMinorPatch.getFromStr(manifest["lastTestedNVDAVersion"])
 		),
 		"channel": channel,
 		"publisher": publisher,

--- a/_validate/majorMinorPatch.py
+++ b/_validate/majorMinorPatch.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2023 Noelia Ruiz Martínez, NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MajorMinorPatch:
+	major: int = 0
+	minor: int = 0
+	patch: int = 0
+
+	@classmethod
+	def getFromStr(cls, version: str) -> "MajorMinorPatch":
+		versionParts = version.split(".")
+		versionLen = len(versionParts)
+		if versionLen < 2 or versionLen > 3:
+			raise ValueError(f"Version string not valid: {version}")
+		return cls(
+			major=int(versionParts[0]),
+			minor=int(versionParts[1]),
+			patch=0 if len(versionParts) == 2 else int(versionParts[2])
+		)
+
+	def __str__(self) -> str:
+		return f"{self.major}.{self.minor}.{self.patch}"


### PR DESCRIPTION
Currently the last tested NVDA version, and the minimum NVDA version for an addon-datastore submission does not have to match with the manifest.

This may be misleading. Validation should be updated to ensure these values match:

- Manifest: minimumNVDAVersion, addon-datastore JSON: minNVDAVersion
- Manifest: lastTestedNVDAVersion, addon-datastore JSON: lastTestedVersion