### PR TITLE
Handle configobj default for manifest url

### DIFF
--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -77,6 +77,10 @@ def _createDictMatchingJsonSchema(
 		licenseName: str,
 		licenseUrl: typing.Optional[str],
 ) -> typing.Dict[str, str]:
+	homepage = manifest.get("url")
+	if homepage == 'None':
+		# The config default is None which is parsed by configobj as a string not a NoneType
+		homepage = None
 	return {  # see _validate/addonVersion_schema.json
 		"addonId": manifest["name"],
 		"displayName": manifest["summary"],
@@ -84,7 +88,7 @@ def _createDictMatchingJsonSchema(
 		"description": manifest["description"],
 		"sha256": sha,
 		# Optional field
-		"homepage": manifest.get("url"),
+		"homepage": homepage,
 		"addonVersionName": manifest["version"],
 		"addonVersionNumber": dataclasses.asdict(
 			MajorMinorPatch.getFromStr(manifest["version"])

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -132,7 +132,11 @@ def checkDescriptionMatches(manifest: AddonManifest, submission: JsonObjT) -> Va
 def checkUrlMatchesHomepage(manifest: AddonManifest, submission: JsonObjT) -> ValidationErrorGenerator:
 	""" The submission homepage must match the *.nvda-addon manifest url field.
 	"""
-	if manifest.get("url") != submission.get("homepage"):
+	manifestUrl = manifest.get("url")
+	if manifestUrl == 'None':
+		# The config default is None which is parsed by configobj as a string not a NoneType
+		manifestUrl = None
+	if manifestUrl != submission.get("homepage"):
 		yield f"Submission 'homepage' must be set to '{manifest.get('url')}' " \
 		f"in json file instead of {submission.get('homepage')}"
 


### PR DESCRIPTION
This PR failed due to configobj parsing url=None in the add-on manifest as a string, rather than a NoneType.

'None' as a value for `url` in the add-on manifest should be handled as a NoneType

https://github.com/nvaccess/addon-datastore/pull/374#issuecomment-1488060016
https://github.com/nvaccess/addon-datastore/actions/runs/4551232543/jobs/8025065974