### PR TITLE
Validate manifest

### DIFF
--- a/_tests/test_createJson.py
+++ b/_tests/test_createJson.py
@@ -52,7 +52,9 @@ class IntegrationTestCreateJson(unittest.TestCase):
 		# Values used must match the manifest files:
 		# - '_tests / testData / manifest.ini'
 		# - '_tests/testData/fake.nvda-addon' (unzip)
+		manifest = getAddonManifest()
 		createJson.generateJsonFile(
+			manifest,
 			ADDON_PACKAGE,
 			self.outputDir,
 			channel="stable",

--- a/_tests/test_validate.py
+++ b/_tests/test_validate.py
@@ -418,7 +418,7 @@ class Validate_checkMinNVDAVersionMatches(unittest.TestCase):
 		self.assertEqual(errors, [])
 
 	def test_invalid(self):
-		self.manifest["minimumNVDAVersion"] = "1999.1.0"
+		self.manifest["minimumNVDAVersion"] = (1999, 1, 0)
 		errors = list(
 			validate.checkMinNVDAVersionMatches(self.manifest, self.submissionData)
 		)
@@ -449,7 +449,7 @@ class Validate_checkLastTestedNVDAVersionMatches(unittest.TestCase):
 		self.assertEqual(errors, [])
 
 	def test_invalid(self):
-		self.manifest["lastTestedNVDAVersion"] = "9999.1.0"
+		self.manifest["lastTestedNVDAVersion"] = (9999, 1, 0)
 		errors = list(
 			validate.checkLastTestedNVDAVersionMatches(self.manifest, self.submissionData)
 		)

--- a/_validate/addonManifest.py
+++ b/_validate/addonManifest.py
@@ -16,7 +16,7 @@ from io import StringIO
 from configobj import ConfigObj
 from configobj.validate import Validator, ValidateError
 
-sys.path.append(os.path.dirname(__file__))  # To allow this module to be run as a script by runcreatejson.bat
+sys.path.append(os.path.dirname(__file__))
 # E402 module level import not at top of file
 from majorMinorPatch import MajorMinorPatch  # noqa:E402
 del sys.path[-1]

--- a/_validate/addonManifest.py
+++ b/_validate/addonManifest.py
@@ -6,7 +6,11 @@
 
 import os
 import sys
-from typing import Tuple
+from typing import (
+	Optional,
+	TextIO,
+	Tuple,
+)
 from io import StringIO
 
 from configobj import ConfigObj
@@ -22,62 +26,66 @@ class AddonManifest(ConfigObj):
 	"""From the NVDA addonHandler module. Should be kept in sync.
 	Add-on manifest file. It contains metadata about an NVDA add-on package. """
 	configspec = ConfigObj(StringIO(
-	"""
-# NVDA Add-on Manifest configuration specification
-# Add-on unique name
-# Suggested convention is lowerCamelCase.
-name = string()
+		"""
+		# NVDA Add-on Manifest configuration specification
+		# Add-on unique name
+		# Suggested convention is lowerCamelCase.
+		name = string()
 
-# short summary (label) of the add-on to show to users.
-summary = string()
+		# short summary (label) of the add-on to show to users.
+		summary = string()
 
-# Long description with further information and instructions
-description = string(default=None)
+		# Long description with further information and instructions
+		description = string(default=None)
 
-# Name of the author or entity that created the add-on
-author = string()
+		# Name of the author or entity that created the add-on
+		author = string()
 
-# Version of the add-on.
-# Suggested convention is <major>.<minor>.<patch> format.
-version = string()
+		# Version of the add-on.
+		# Suggested convention is <major>.<minor>.<patch> format.
+		version = string()
 
-# The minimum required NVDA version for this add-on to work correctly.
-# Should be less than or equal to lastTestedNVDAVersion
-minimumNVDAVersion = apiVersion(default="0.0.0")
+		# The minimum required NVDA version for this add-on to work correctly.
+		# Should be less than or equal to lastTestedNVDAVersion
+		minimumNVDAVersion = apiVersion(default="0.0.0")
 
-# Must be greater than or equal to minimumNVDAVersion
-lastTestedNVDAVersion = apiVersion(default="0.0.0")
+		# Must be greater than or equal to minimumNVDAVersion
+		lastTestedNVDAVersion = apiVersion(default="0.0.0")
 
-# URL for more information about the add-on, e.g. a homepage.
-# Should begin with https://
-url = string(default=None)
+		# URL for more information about the add-on, e.g. a homepage.
+		# Should begin with https://
+		url = string(default=None)
 
-# Name of default documentation file for the add-on.
-docFileName = string(default=None)
+		# Name of default documentation file for the add-on.
+		docFileName = string(default=None)
 
-# NOTE: apiVersion:
-# EG: 2019.1.0 or 0.0.0
-# Must have 3 integers separated by dots.
-# The first integer must be a Year (4 characters)
-# "0.0.0" is also valid.
-# The final integer can be left out, and in that case will default to 0. E.g. 2019.1
+		# NOTE: apiVersion:
+		# EG: 2019.1.0 or 0.0.0
+		# Must have 3 integers separated by dots.
+		# The first integer must be a Year (4 characters)
+		# "0.0.0" is also valid.
+		# The final integer can be left out, and in that case will default to 0. E.g. 2019.1
 
-"""))
+		"""
+	))
 
-	def __init__(self, input, translatedInput=None):
+	def __init__(self, input: TextIO, translatedInput: Optional[TextIO] = None):
 		""" Constructs an L{AddonManifest} instance from manifest string data
 		@param input: data to read the manifest information
-		@type input: a fie-like object.
 		@param translatedInput: translated manifest input
-		@type translatedInput: file-like object
 		"""
-		super(AddonManifest, self).__init__(input, configspec=self.configspec, encoding='utf-8', default_encoding='utf-8')
-		self._errors = None
+		super().__init__(
+			input,
+			configspec=self.configspec,
+			encoding='utf-8',
+			default_encoding='utf-8',
+		)
+		self._errors: Optional[str] = None
 		val = Validator({"apiVersion": validate_apiVersionString})
 		result = self.validate(val, copy=True, preserve_errors=True)
-		if result != True:
+		if result is not True:
 			self._errors = result
-		elif True != self._validateApiVersionRange():
+		elif self._validateApiVersionRange() is not True:
 			self._errors = "Constraint not met: minimumNVDAVersion ({}) <= lastTestedNVDAVersion ({})".format(
 				self.get("minimumNVDAVersion"),
 				self.get("lastTestedNVDAVersion")
@@ -85,16 +93,16 @@ docFileName = string(default=None)
 		self._translatedConfig = None
 		if translatedInput is not None:
 			self._translatedConfig = ConfigObj(translatedInput, encoding='utf-8', default_encoding='utf-8')
-			for k in ('summary','description'):
-				val=self._translatedConfig.get(k)
+			for key in ('summary', 'description'):
+				val = self._translatedConfig.get(key)
 				if val:
-					self[k]=val
+					self[key] = val
 
 	@property
-	def errors(self):
+	def errors(self) -> str:
 		return self._errors
 
-	def _validateApiVersionRange(self):
+	def _validateApiVersionRange(self) -> bool:
 		lastTested = self.get("lastTestedNVDAVersion")
 		minRequiredVersion = self.get("minimumNVDAVersion")
 		return minRequiredVersion <= lastTested
@@ -105,7 +113,10 @@ def validate_apiVersionString(value: str) -> Tuple[int, int, int]:
 	if not value or value == "None":
 		return (0, 0, 0)
 	if not isinstance(value, str):
-		raise ValidateError('Expected an apiVersion in the form of a string. EG "2019.1.0"')
+		raise ValidateError(
+			"Expected an apiVersion in the form of a string. "
+			f"e.g. '2019.1.0' instead of {value} (type {type(value)})"
+		)
 	try:
 		versionParsed = MajorMinorPatch.getFromStr(value)
 		return (versionParsed.major, versionParsed.minor, versionParsed.patch)

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -82,6 +82,11 @@ def _createDictMatchingJsonSchema(
 		licenseUrl: Optional[str],
 ) -> Dict[str, str]:
 	"""Refer to _validate/addonVersion_schema.json"""
+	try:
+		addonVersionNumber = MajorMinorPatch.getFromStr(manifest["version"])
+	except ValueError:
+		manifest._errors = f"Manifest version invalid {addonVersionNumber}"
+		raise
 	addonData = {
 		"addonId": manifest["name"],
 		"displayName": manifest["summary"],
@@ -89,9 +94,7 @@ def _createDictMatchingJsonSchema(
 		"description": manifest["description"],
 		"sha256": sha,
 		"addonVersionName": manifest["version"],
-		"addonVersionNumber": dataclasses.asdict(
-			MajorMinorPatch.getFromStr(manifest["version"])
-		),
+		"addonVersionNumber": dataclasses.asdict(addonVersionNumber),
 		"minNVDAVersion": dataclasses.asdict(
 			MajorMinorPatch(*manifest["minimumNVDAVersion"])
 		),

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -9,7 +9,11 @@ import argparse
 import os
 import sys
 
-import typing
+from typing import (
+	Dict,
+	Optional,
+	cast,
+)
 
 sys.path.append(os.path.dirname(__file__))  # To allow this module to be run as a script by runcreatejson.bat
 # E402 module level import not at top of file
@@ -27,6 +31,7 @@ def getSha256(addonPath: str) -> str:
 
 
 def generateJsonFile(
+		manifest: AddonManifest,
 		addonPath: str,
 		parentDir: str,
 		channel: str,
@@ -34,9 +39,8 @@ def generateJsonFile(
 		sourceUrl: str,
 		url: str,
 		licenseName: str,
-		licenseUrl: typing.Optional[str],
+		licenseUrl: Optional[str],
 ) -> None:
-	manifest = getAddonManifest(addonPath)
 	data = _createDictMatchingJsonSchema(
 		manifest=manifest,
 		sha=getSha256(addonPath),
@@ -64,7 +68,7 @@ def buildOutputFilePath(data, parentDir) -> os.PathLike:
 	if not os.path.isdir(addonDir):
 		os.makedirs(addonDir)
 	filePath = os.path.join(addonDir, f'{canonicalVersionString}.json')
-	return typing.cast(os.PathLike, filePath)
+	return cast(os.PathLike, filePath)
 
 
 def _createDictMatchingJsonSchema(
@@ -75,8 +79,8 @@ def _createDictMatchingJsonSchema(
 		sourceUrl: str,
 		url: str,
 		licenseName: str,
-		licenseUrl: typing.Optional[str],
-) -> typing.Dict[str, str]:
+		licenseUrl: Optional[str],
+) -> Dict[str, str]:
 	"""Refer to _validate/addonVersion_schema.json"""
 	addonData = {
 		"addonId": manifest["name"],
@@ -89,10 +93,10 @@ def _createDictMatchingJsonSchema(
 			MajorMinorPatch.getFromStr(manifest["version"])
 		),
 		"minNVDAVersion": dataclasses.asdict(
-			MajorMinorPatch.getFromStr(manifest["minimumNVDAVersion"])
+			MajorMinorPatch(*manifest["minimumNVDAVersion"])
 		),
 		"lastTestedVersion": dataclasses.asdict(
-			MajorMinorPatch.getFromStr(manifest["lastTestedNVDAVersion"])
+			MajorMinorPatch(*manifest["lastTestedNVDAVersion"])
 		),
 		"channel": channel,
 		"publisher": publisher,
@@ -125,6 +129,12 @@ def main():
 		dest="parentDir",
 		help="Parent directory to store the json file.",
 		required=True,
+	)
+	parser.add_argument(
+		"--output",
+		dest="errorOutputFile",
+		help="The text file to output errors from the validation, if any.",
+		default=None,
 	)
 	parser.add_argument(
 		"--channel",
@@ -164,7 +174,17 @@ def main():
 		required=False,
 	)
 	args = parser.parse_args()
+
+	manifest = getAddonManifest(args.file)
+	if manifest.errors:
+		errorFilePath: Optional[str] = args.errorOutputFile
+		if errorFilePath:
+			with open(errorFilePath, "w") as errorFile:
+				errorFile.write(f"Validation Errors:\n{manifest.errors}")
+		raise ValueError(f"Invalid manifest file: {manifest.errors}")
+
 	generateJsonFile(
+		manifest=manifest,
 		addonPath=args.file,
 		parentDir=args.parentDir,
 		channel=args.channel,

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -17,7 +17,7 @@ from jsonschema import validate, exceptions
 sys.path.append(os.path.dirname(__file__))  # To allow this module to be run as a script by runValidate.bat
 # E402 module level import not at top of file
 import sha256  # noqa:E402
-from addonManifest import AddonManifest, validate_apiVersionString   # noqa:E402
+from addonManifest import AddonManifest  # noqa:E402
 from manifestLoader import getAddonManifest, TEMP_DIR  # noqa:E402
 from majorMinorPatch import MajorMinorPatch  # noqa:E402
 del sys.path[-1]
@@ -241,7 +241,7 @@ def checkMinNVDAVersionMatches(
 		manifest: AddonManifest,
 		submission: JsonObjT
 ) -> ValidationErrorGenerator:
-	manifestMinimumNVDAVersion = MajorMinorPatch(*validate_apiVersionString(manifest["minimumNVDAVersion"]))
+	manifestMinimumNVDAVersion = MajorMinorPatch(*manifest["minimumNVDAVersion"])
 	minNVDAVersion = MajorMinorPatch(**submission["minNVDAVersion"])
 	if manifestMinimumNVDAVersion != minNVDAVersion:
 		yield (
@@ -254,7 +254,7 @@ def checkLastTestedNVDAVersionMatches(
 		manifest: AddonManifest,
 		submission: JsonObjT
 ) -> ValidationErrorGenerator:
-	manifestLastTestedNVDAVersion = MajorMinorPatch(*validate_apiVersionString(manifest["lastTestedNVDAVersion"]))
+	manifestLastTestedNVDAVersion = MajorMinorPatch(*manifest["lastTestedNVDAVersion"])
 	lastTestedVersion = MajorMinorPatch(**submission["lastTestedVersion"])
 	if manifestLastTestedNVDAVersion != lastTestedVersion:
 		yield (

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -17,7 +17,7 @@ from jsonschema import validate, exceptions
 sys.path.append(os.path.dirname(__file__))  # To allow this module to be run as a script by runValidate.bat
 # E402 module level import not at top of file
 import sha256  # noqa:E402
-from addonManifest import AddonManifest   # noqa:E402
+from addonManifest import AddonManifest, validate_apiVersionString   # noqa:E402
 from manifestLoader import getAddonManifest, TEMP_DIR  # noqa:E402
 from majorMinorPatch import MajorMinorPatch  # noqa:E402
 del sys.path[-1]
@@ -241,7 +241,7 @@ def checkMinNVDAVersionMatches(
 		manifest: AddonManifest,
 		submission: JsonObjT
 ) -> ValidationErrorGenerator:
-	manifestMinimumNVDAVersion = MajorMinorPatch.getFromStr(manifest["minimumNVDAVersion"])
+	manifestMinimumNVDAVersion = MajorMinorPatch(*validate_apiVersionString(manifest["minimumNVDAVersion"]))
 	minNVDAVersion = MajorMinorPatch(**submission["minNVDAVersion"])
 	if manifestMinimumNVDAVersion != minNVDAVersion:
 		yield (
@@ -254,7 +254,7 @@ def checkLastTestedNVDAVersionMatches(
 		manifest: AddonManifest,
 		submission: JsonObjT
 ) -> ValidationErrorGenerator:
-	manifestLastTestedNVDAVersion = MajorMinorPatch.getFromStr(manifest["lastTestedNVDAVersion"])
+	manifestLastTestedNVDAVersion = MajorMinorPatch(*validate_apiVersionString(manifest["lastTestedNVDAVersion"]))
 	lastTestedVersion = MajorMinorPatch(**submission["lastTestedVersion"])
 	if manifestLastTestedNVDAVersion != lastTestedVersion:
 		yield (


### PR DESCRIPTION
The manifest file is not validated according to the NVDA spec when generating the JSON file.
This can cause uncaught errors to occur when generating the JSON.
When validating a manifest file, validation errors should be saved to an output file, so that they can be posted as a comment via GitHub actions.

Example failure, where no message was provided to the author:
https://github.com/nvaccess/addon-datastore/issues/510
This PR should have also succeeded as `None` in the manifest should be parsed to `0.0.0`

```python
Traceback (most recent call last):
  File "D:\a\addon-datastore\addon-datastore\validation\\_validate\createJson.py", line 1[81](https://github.com/nvaccess/addon-datastore/actions/runs/4765294123/jobs/8470847985#step:7:82), in <module>
    main()
  File "D:\a\addon-datastore\addon-datastore\validation\\_validate\createJson.py", line 167, in main
    generateJsonFile(
  File "D:\a\addon-datastore\addon-datastore\validation\\_validate\createJson.py", line 40, in generateJsonFile
    data = _createDictMatchingJsonSchema(
  File "D:\a\addon-datastore\addon-datastore\validation\\_validate\createJson.py", line 92, in _createDictMatchingJsonSchema
    MajorMinorPatch.getFromStr(manifest["minimumNVDAVersion"])
  File "D:\a\addon-datastore\addon-datastore\validation\_validate\majorMinorPatch.py", line 19, in getFromStr
    raise ValueError(f"Version string not valid: {version}")
ValueError: Version string not valid: None
Deactivating NVDA Python virtual environment
Error: Process completed with exit code 1.
```