### PR TITLE
Support validating multiple files using glob

### DIFF
--- a/_tests/test_validate.py
+++ b/_tests/test_validate.py
@@ -675,18 +675,6 @@ class Validate_checkVersions(unittest.TestCase):
 		)
 
 
-class Validate_outputResult(unittest.TestCase):
-
-	def test_output_errorRaises(self):
-		singleErrorGen = ("error string" for _ in range(1))
-		with self.assertRaises(ValueError):
-			validate.outputResult(singleErrorGen)
-
-	def test_output_noError(self):
-		noErrorGen = ("error string" for _ in range(0))
-		validate.outputResult(noErrorGen)
-
-
 class Validate_End2End(unittest.TestCase):
 
 	class OpenUrlResult:
@@ -724,7 +712,7 @@ class Validate_End2End(unittest.TestCase):
 			validate.validateSubmission(VALID_SUBMISSION_JSON_FILE, VERSIONS_FILE)
 		)
 		self.assertEqual(
-			list(errors),
+			errors,
 			[
 				'Download of addon failed',
 				'Fatal error, unable to continue: Unable to download from '

--- a/_validate/addonVersion_schema.json
+++ b/_validate/addonVersion_schema.json
@@ -214,17 +214,17 @@
 			"examples": [
 				"https://github.com/nvaccess/addon-datastore/license.MD"
 			],
-			"title": "The licenseURL schema",
+			"title": "The URL of the license",
 			"type": "string"
 		},
 		"legacy": {
 			"$id": "#/properties/legacy",
 			"default": false,
-			"description": "Boolean indicating if the add-on should be marked as legacy.",
+			"description": "Legacy add-ons have invalid data or manifest. Legacy add-ons are not listed in the NVDA add-on store.",
 			"examples": [
 				true
 			],
-			"title": "The legacy schema",
+			"title": "Mark add-on as legacy",
 			"type": "boolean"
 		}
 	},


### PR DESCRIPTION
This PR adds support for validating multiple files, by providing a glob for the file path for add-ons. For example `addons/*/*.json`, `addons/nvdaRemote/*.json`, or `addons/nvdaRemote/1.2.3.json`.

This PR also stops validation from being performed on files marked as "legacy". This is because legacy add-ons have invalid data or manifest.

This has been tested locally with add-on store data.
`.\runvalidate.bat ..\addon-datastore\addons\*\*.json ..\addon-datastore-transform\nvdaAPIVersions.json .\validationErrors.md`

Add-on store data has been updated in https://github.com/nvaccess/addon-datastore/pull/575 to ensure all current submitted add-ons are valid.
This has also been tested via https://github.com/nvaccess/addon-datastore/pull/575 and [this GitHub action run](https://github.com/nvaccess/addon-datastore-staging/actions/runs/4825505830/jobs/8596423218).