### PR TITLE
Generate translations with add-on submissions

### DIFF
--- a/_tests/testData/addons/fake/13.0.0.json
+++ b/_tests/testData/addons/fake/13.0.0.json
@@ -26,5 +26,6 @@
 	"sha256": "e27fa778cb99f83ececeb0bc089033929eab5a2fa475ce63e68f50b03b6ab585",
 	"sourceURL": "https://github.com/nvaccess/dont/use/this/address",
 	"license": "GPL v2",
-	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html"
+	"licenseURL": "https://www.gnu.org/licenses/gpl-2.0.html",
+	"translations": []
 }

--- a/_validate/addonVersion_schema.json
+++ b/_validate/addonVersion_schema.json
@@ -27,7 +27,14 @@
 			"sha256": "69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82",
 			"sourceURL": "https://github.com/nvaccess/addon-datastore/",
 			"license": "GPL v2",
-			"licenseURL": "https://github.com/nvaccess/addon-datastore/license.MD"
+			"licenseURL": "https://github.com/nvaccess/addon-datastore/license.MD",
+			"translations": [
+				{
+					"language": "de",
+					"displayName": "Mein Addon",
+					"description": "erleichtert das Durchführen von xyz"
+				}
+			]
 		}
 	],
 	"title": "Root",
@@ -48,7 +55,8 @@
 		"URL",
 		"sha256",
 		"sourceURL",
-		"license"
+		"license",
+		"translations"
 	],
 	"properties": {
 		"addonId": {
@@ -66,6 +74,7 @@
 			"title": "The addon version number",
 			"description": "Pure numerical representation of the version being released.",
 			"default": {},
+			"type": "object",
 			"examples": [
 				{
 					"major": 21,
@@ -226,6 +235,25 @@
 			],
 			"title": "Mark add-on as legacy",
 			"type": "boolean"
+		},
+		"translations": {
+			"$id": "#/properties/translations",
+			"default": [],
+			"description": "A collections of translations generated from localized add-on manifests",
+			"examples": [
+				[
+					{
+						"language": "de",
+						"displayName": "Mein Addon",
+						"description": "erleichtert das Durchführen von xyz"
+					}
+				]
+			],
+			"title": "Translations",
+			"type": "array",
+			"items": {
+				"$ref": "#/$defs/translation"
+			}
 		}
 	},
 	"$defs": {
@@ -273,6 +301,52 @@
 					],
 					"title": "The 'patch' part of the version number.",
 					"type": "integer"
+				}
+			}
+		},
+		"translation": {
+			"default": {},
+			"type": "object",
+			"examples": [
+				{
+					"language": "de",
+					"displayName": "Mein Addon",
+					"description": "erleichtert das Durchführen von xyz"
+				}
+			],
+			"required": [
+				"language",
+				"displayName",
+				"description"
+			],
+			"properties": {
+				"language": {
+					"default": "",
+					"description": "Language code supported by NVDA",
+					"examples": [
+						"de",
+						"pt_BR"
+					],
+					"title": "Language code",
+					"type": "string"
+				},
+				"displayName": {
+					"default": "",
+					"description": "The translated name that will be displayed for the addon.",
+					"examples": [
+						"Mein Addon"
+					],
+					"title": "The translated display name",
+					"type": "string"
+				},
+				"description": {
+					"default": "",
+					"description": "The translated description that will be displayed for the addon.",
+					"examples": [
+						"erleichtert das Durchführen von xyz"
+					],
+					"title": "The translated description",
+					"type": "string"
 				}
 			}
 		}

--- a/_validate/addonVersion_schema.json
+++ b/_validate/addonVersion_schema.json
@@ -336,12 +336,12 @@
 					"examples": [
 						"Mein Addon"
 					],
-					"title": "The translated display name",
+					"title": "Translated display name",
 					"type": "string"
 				},
 				"description": {
 					"default": "",
-					"description": "The translated description that will be displayed for the addon.",
+					"description": "Translated description that will be displayed for the addon.",
 					"examples": [
 						"erleichtert das Durchführen von xyz"
 					],

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -19,7 +19,7 @@ from typing import (
 sys.path.append(os.path.dirname(__file__))  # To allow this module to be run as a script by runcreatejson.bat
 # E402 module level import not at top of file
 from addonManifest import AddonManifest  # noqa:E402
-from manifestLoader import getAddonManifest  # noqa:E402
+from manifestLoader import getAddonManifest, getAddonManifestLocalizations  # noqa:E402
 from majorMinorPatch import MajorMinorPatch  # noqa:E402
 import sha256  # noqa:E402
 del sys.path[-1]
@@ -116,6 +116,16 @@ def _createDictMatchingJsonSchema(
 		addonData["homepage"] = homepage
 	if licenseUrl:
 		addonData["licenseURL"] = licenseUrl
+
+	addonData["translations"] = []
+	for langCode, manifest in getAddonManifestLocalizations(manifest):
+		addonData["translations"].append(
+			{
+				"language": langCode,
+				"displayName": manifest["summary"],
+				"description": manifest["description"],
+			}
+		)
 
 	return addonData
 

--- a/_validate/manifestLoader.py
+++ b/_validate/manifestLoader.py
@@ -2,7 +2,10 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
+from glob import glob
 import os
+import pathlib
+from typing import Generator, Tuple
 import zipfile
 from addonManifest import AddonManifest
 import tempfile
@@ -23,3 +26,23 @@ def getAddonManifest(addonPath: str) -> AddonManifest:
 		return manifest
 	except Exception as err:
 		raise err
+
+
+def getAddonManifestLocalizations(
+		manifest: AddonManifest
+) -> Generator[Tuple[str, AddonManifest], None, None]:
+	""" Extract data from translated manifest.ini from *.nvda-addon and parse.
+	Raise on error.
+	"""
+	if manifest.filename is None:
+		# Ignore during tests
+		return
+	addonFolder = pathlib.Path(manifest.filename).parent.absolute().as_posix()
+	filePaths = os.path.join(addonFolder, "locale", "*", "manifest.ini")
+	for translationFile in glob(filePaths):
+		languageCode = pathlib.Path(translationFile).parent.name
+		translatedManifest = AddonManifest(translationFile)
+		try:
+			yield languageCode, translatedManifest
+		except Exception as err:
+			raise err

--- a/_validate/manifestLoader.py
+++ b/_validate/manifestLoader.py
@@ -41,8 +41,8 @@ def getAddonManifestLocalizations(
 	filePaths = os.path.join(addonFolder, "locale", "*", "manifest.ini")
 	for translationFile in glob(filePaths):
 		languageCode = pathlib.Path(translationFile).parent.name
-		translatedManifest = AddonManifest(translationFile)
 		try:
+			translatedManifest = AddonManifest(translationFile)
 			yield languageCode, translatedManifest
 		except Exception as err:
-			raise err
+			print(f"Error in {translationFile} {err}")

--- a/_validate/manifestLoader.py
+++ b/_validate/manifestLoader.py
@@ -44,5 +44,5 @@ def getAddonManifestLocalizations(
 		try:
 			translatedManifest = AddonManifest(translationFile)
 			yield languageCode, translatedManifest
-		except Exception as err:
+		except Exception:
 			print(f"Error in {translationFile}")

--- a/_validate/manifestLoader.py
+++ b/_validate/manifestLoader.py
@@ -45,4 +45,4 @@ def getAddonManifestLocalizations(
 			translatedManifest = AddonManifest(translationFile)
 			yield languageCode, translatedManifest
 		except Exception as err:
-			print(f"Error in {translationFile} {err}")
+			print(f"Error in {translationFile}")

--- a/_validate/regenerateTranslations.py
+++ b/_validate/regenerateTranslations.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2023 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import argparse
+import glob
+import json
+import os
+import sys
+from urllib.request import urlretrieve
+
+from typing import (
+	Optional,
+)
+
+sys.path.append(os.path.dirname(__file__))  # To allow this module to be run as a script by runcreatejson.bat
+# E402 module level import not at top of file
+from manifestLoader import getAddonManifest, getAddonManifestLocalizations, TEMP_DIR  # noqa:E402
+del sys.path[-1]
+
+
+def regenerateJsonFile(filePath: str, errorFilePath: Optional[str]) -> None:
+	with open(filePath) as f:
+		addonData = json.load(f)
+	addonData["translations"] = []
+	addonFilePath = os.path.join(TEMP_DIR, "addon.nvda-addon")
+	urlretrieve(addonData["URL"], addonFilePath)
+	manifest = getAddonManifest(addonFilePath)
+	if manifest.errors:
+		if errorFilePath:
+			with open(errorFilePath, "w") as errorFile:
+				errorFile.write(f"Validation Errors:\n{manifest.errors}")
+		raise ValueError(f"Invalid manifest file: {manifest.errors}")
+
+	for langCode, manifest in getAddonManifestLocalizations(manifest):
+		addonData["translations"].append(
+			{
+				"language": langCode,
+				"displayName": manifest["summary"],
+				"description": manifest["description"],
+			}
+		)
+	
+	with open(filePath, "wt") as f:
+		json.dump(addonData, f, indent="\t")
+	print(f"Wrote json file: {filePath}")
+
+
+def main():
+	parser = argparse.ArgumentParser()
+	parser.add_argument(
+		"--dir",
+		dest="parentDir",
+		help="Parent directory to regenerate the JSON files inside.",
+		required=True,
+	)
+	parser.add_argument(
+		"--output",
+		dest="errorOutputFile",
+		help="The text file to output errors from the validation, if any.",
+		default=None,
+	)
+	args = parser.parse_args()
+	errorFilePath: Optional[str] = args.errorOutputFile
+	for addonJsonFile in glob.glob(f"{args.parentDir}/**/*.json"):
+		regenerateJsonFile(addonJsonFile, errorFilePath)
+
+
+if __name__ == '__main__':
+	main()

--- a/_validate/regenerateTranslations.py
+++ b/_validate/regenerateTranslations.py
@@ -24,6 +24,8 @@ del sys.path[-1]
 def regenerateJsonFile(filePath: str, errorFilePath: Optional[str]) -> None:
 	with open(filePath) as f:
 		addonData = json.load(f)
+	if addonData.get("legacy"):
+		return
 	addonData["translations"] = []
 	addonFilePath = os.path.join(TEMP_DIR, "addon.nvda-addon")
 	urlretrieve(addonData["URL"], addonFilePath)
@@ -32,7 +34,7 @@ def regenerateJsonFile(filePath: str, errorFilePath: Optional[str]) -> None:
 		if errorFilePath:
 			with open(errorFilePath, "w") as errorFile:
 				errorFile.write(f"Validation Errors:\n{manifest.errors}")
-		raise ValueError(f"Invalid manifest file: {manifest.errors}")
+		return
 
 	for langCode, manifest in getAddonManifestLocalizations(manifest):
 		addonData["translations"].append(

--- a/regenerateTranslations.ps1
+++ b/regenerateTranslations.ps1
@@ -1,0 +1,3 @@
+# Regenerate translations for files in dir
+$ErrorActionPreference = "Stop";
+& "$PSScriptRoot\venvUtils\venvCmd" "$PSScriptRoot\_validate\regenerateTranslations.py" $args


### PR DESCRIPTION
Append all translations to the add-on submission when creating the JSON submission file from a downloaded add-on manifest.

Adds a script to regenerate translations for all add-ons.

Translations for displayName and description are append to the JSON submission file.
These translations will be used for the transformation to views in a subsequent PR to `-transform`:
- [ ] https://github.com/nvaccess/addon-datastore-transform/pull/23
- [ ] https://github.com/nvaccess/addon-datastore/pull/1095