### PR TITLE
Require stable API version for submitting an add-on using stable channel

### DIFF
--- a/_tests/testData/nvdaAPIVersions.json
+++ b/_tests/testData/nvdaAPIVersions.json
@@ -37,5 +37,19 @@
 			"minor": 1,
 			"patch": 0
 		}
+	},
+	{
+		"description": "NVDA 2024.1",
+		"apiVer": {
+			"major": 2024,
+			"minor": 1,
+			"patch": 0
+		},
+		"backCompatTo": {
+			"major": 2024,
+			"minor": 1,
+			"patch": 0
+		},
+		"experimental": true
 	}
 ]

--- a/_tests/test_validate.py
+++ b/_tests/test_validate.py
@@ -302,7 +302,7 @@ class validate_getExistingVersions(unittest.TestCase):
 		formattedVersions = list(validate.getExistingVersions(self.verFilename))
 		self.assertEqual(
 			formattedVersions,
-			["0.0.0", "2022.1.0", "2023.1.0"]
+			["0.0.0", "2022.1.0", "2023.1.0", "2024.1.0"]
 		)
 
 
@@ -352,6 +352,29 @@ class validate_checkLastTestedVersionExists(unittest.TestCase):
 			["Last tested version error: 9999.3.0 doesn't exist"]
 		)
 
+	def test_validExperimental(self):
+		self.submissionData["lastTestedVersion"]["major"] = 2024
+		self.submissionData["lastTestedVersion"]["minor"] = 1
+		self.submissionData["lastTestedVersion"]["patch"] = 0
+		self.submissionData["channel"] = "beta"
+		self.assertEqual(
+			list(validate.checkLastTestedVersionExist(self.submissionData, self.verFilename)),
+			[]
+		)
+
+	def test_invalidExperimental(self):
+		self.submissionData["lastTestedVersion"]["major"] = 2024
+		self.submissionData["lastTestedVersion"]["minor"] = 1
+		self.submissionData["lastTestedVersion"]["patch"] = 0
+		self.submissionData["channel"] = "stable"
+		self.assertEqual(
+			list(validate.checkLastTestedVersionExist(self.submissionData, self.verFilename)),
+			[
+				"Last tested version error: 2024.1.0 is not stable yet. "
+				"Please submit add-on using the beta or dev channel."
+			]
+		)
+
 
 class validate_checkMinRequiredVersionExists(unittest.TestCase):
 	"""Test for the checkMinRequiredVersionExists function."""
@@ -397,6 +420,29 @@ class validate_checkMinRequiredVersionExists(unittest.TestCase):
 		self.assertEqual(
 			list(validate.checkMinRequiredVersionExist(self.submissionData, self.verFilename)),
 			["Minimum required version error: 9999.3.0 doesn't exist"]
+		)
+
+	def test_validExperimental(self):
+		self.submissionData["minNVDAVersion"]["major"] = 2024
+		self.submissionData["minNVDAVersion"]["minor"] = 1
+		self.submissionData["minNVDAVersion"]["patch"] = 0
+		self.submissionData["channel"] = "beta"
+		self.assertEqual(
+			list(validate.checkMinRequiredVersionExist(self.submissionData, self.verFilename)),
+			[]
+		)
+
+	def test_invalidExperimental(self):
+		self.submissionData["minNVDAVersion"]["major"] = 2024
+		self.submissionData["minNVDAVersion"]["minor"] = 1
+		self.submissionData["minNVDAVersion"]["patch"] = 0
+		self.submissionData["channel"] = "stable"
+		self.assertEqual(
+			list(validate.checkMinRequiredVersionExist(self.submissionData, self.verFilename)),
+			[
+				"Minimum required version error: 2024.1.0 is not stable yet. "
+				"Please submit add-on using the beta or dev channel."
+			]
 		)
 
 

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -293,7 +293,7 @@ def checkLastTestedVersionExist(submission: JsonObjT, verFilename: str) -> Valid
 		submission["channel"] == "stable"
 		and formattedLastTestedVersion not in getExistingStableVersions(verFilename)
 	):
-		yield f"Last tested version error: {formattedLastTestedVersion} is not stable yet. "
+		yield f"Last tested version error: {formattedLastTestedVersion} is not stable yet. " + \
 		"Please submit add-on using the beta or dev channel."
 
 
@@ -307,7 +307,7 @@ def checkMinRequiredVersionExist(submission: JsonObjT, verFilename: str) -> Vali
 		submission["channel"] == "stable"
 		and formattedMinRequiredVersion not in getExistingStableVersions(verFilename)
 	):
-		yield f"Minimum required version error: {formattedMinRequiredVersion} is not stable yet. "
+		yield f"Minimum required version error: {formattedMinRequiredVersion} is not stable yet. " + \
 		"Please submit add-on using the beta or dev channel."
 
 

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -52,8 +52,16 @@ def getExistingVersions(verFilename: str) -> List[str]:
 	"""Loads API versions file and returns list of versions formatted as strings.
 	"""
 	with open(verFilename) as f:
-		data: JsonObjT = json.load(f)
+		data: List[JsonObjT] = json.load(f)
 	return [_formatVersionString(version["apiVer"].values()) for version in data]
+
+
+def getExistingStableVersions(verFilename: str) -> List[str]:
+	"""Loads API versions file and returns list of stable versions formatted as strings.
+	"""
+	with open(verFilename) as f:
+		data: List[JsonObjT] = json.load(f)
+	return [_formatVersionString(version["apiVer"].values()) for version in data if not version.get("experimental", False)]
 
 
 def _validateJson(data: JsonObjT) -> None:
@@ -276,6 +284,9 @@ def checkLastTestedVersionExist(submission: JsonObjT, verFilename: str) -> Valid
 	formattedLastTestedVersion: str = _formatVersionString(lastTestedVersion.values())
 	if formattedLastTestedVersion not in getExistingVersions(verFilename):
 		yield f"Last tested version error: {formattedLastTestedVersion} doesn't exist"
+	if submission["channel"] == "stable" and formattedLastTestedVersion not in getExistingStableVersions(verFilename):
+		yield f"Last tested version error: {formattedLastTestedVersion} is not stable yet. "
+		"Please submit add-on using the beta or dev channel."
 
 
 def checkMinRequiredVersionExist(submission: JsonObjT, verFilename: str) -> ValidationErrorGenerator:
@@ -283,6 +294,9 @@ def checkMinRequiredVersionExist(submission: JsonObjT, verFilename: str) -> Vali
 	formattedMinRequiredVersion: str = _formatVersionString(minRequiredVersion.values())
 	if formattedMinRequiredVersion not in getExistingVersions(verFilename):
 		yield f"Minimum required version error: {formattedMinRequiredVersion} doesn't exist"
+	if submission["channel"] == "stable" and formattedMinRequiredVersion not in getExistingStableVersions(verFilename):
+		yield f"Minimum required version error: {formattedMinRequiredVersion} is not stable yet. "
+		"Please submit add-on using the beta or dev channel."
 
 
 def checkVersions(

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -61,7 +61,11 @@ def getExistingStableVersions(verFilename: str) -> List[str]:
 	"""
 	with open(verFilename) as f:
 		data: List[JsonObjT] = json.load(f)
-	return [_formatVersionString(version["apiVer"].values()) for version in data if not version.get("experimental", False)]
+	return [
+		_formatVersionString(version["apiVer"].values())
+		for version in data
+		if not version.get("experimental", False)
+	]
 
 
 def _validateJson(data: JsonObjT) -> None:
@@ -284,7 +288,11 @@ def checkLastTestedVersionExist(submission: JsonObjT, verFilename: str) -> Valid
 	formattedLastTestedVersion: str = _formatVersionString(lastTestedVersion.values())
 	if formattedLastTestedVersion not in getExistingVersions(verFilename):
 		yield f"Last tested version error: {formattedLastTestedVersion} doesn't exist"
-	if submission["channel"] == "stable" and formattedLastTestedVersion not in getExistingStableVersions(verFilename):
+
+	elif (
+		submission["channel"] == "stable"
+		and formattedLastTestedVersion not in getExistingStableVersions(verFilename)
+	):
 		yield f"Last tested version error: {formattedLastTestedVersion} is not stable yet. "
 		"Please submit add-on using the beta or dev channel."
 
@@ -294,7 +302,11 @@ def checkMinRequiredVersionExist(submission: JsonObjT, verFilename: str) -> Vali
 	formattedMinRequiredVersion: str = _formatVersionString(minRequiredVersion.values())
 	if formattedMinRequiredVersion not in getExistingVersions(verFilename):
 		yield f"Minimum required version error: {formattedMinRequiredVersion} doesn't exist"
-	if submission["channel"] == "stable" and formattedMinRequiredVersion not in getExistingStableVersions(verFilename):
+
+	elif (
+		submission["channel"] == "stable"
+		and formattedMinRequiredVersion not in getExistingStableVersions(verFilename)
+	):
 		yield f"Minimum required version error: {formattedMinRequiredVersion} is not stable yet. "
 		"Please submit add-on using the beta or dev channel."
 


### PR DESCRIPTION
Currently add-on authors are able to submit stable add-ons to the 2024.1 API.
However, the 2024.1 API is not stable yet.
If a user attempts to install an add-on that is currently marked as compatible with 2024.1, with the final NVDA 2024.1 release, they will encounter errors.

Add-on authors are encouraged to submit add-ons using the "dev" version to NVDA APIs which are not yet released.

This PR makes it required for an add-on to use dev or beta channels when submitting an add-on to an API version that is still in development, and is yet to be released.

For example:
- in [nvdaAPIVersions.json](https://github.com/nvaccess/addon-datastore-transform/blob/main/nvdaAPIVersions.json), 2024.1 will include a flag `"experimental": true` until RC is reached
- when submitting an add-on with a "stable" channel to 2024.1, the submission will fail with an error encouraging the submitter to use the beta or dev channel