### PR TITLE
Add reviewUrl to the json schema

### DIFF
--- a/_validate/addonVersion_schema.json
+++ b/_validate/addonVersion_schema.json
@@ -34,8 +34,10 @@
 					"displayName": "Mein Addon",
 					"description": "erleichtert das Durchführen von xyz"
 				}
-			]
+			],
+			"reviewUrl": "https://github.com/nvaccess/addon-datastore/discussions/1942#discussioncomment-7453248"
 		}
+
 	],
 	"title": "Root",
 	"type": "object",
@@ -253,6 +255,16 @@
 			"type": "array",
 			"items": {
 				"$ref": "#/$defs/translation"
+			},
+			"reviewUrl": {
+				"$id": "#/properties/reviewUrl",
+				"default": "",
+				"description": "A URL to the discussion comment to review the add-on version.",
+				"examples": [
+					"https://github.com/nvaccess/addon-datastore/discussions/1942#discussioncomment-7453248"
+				],
+				"title": "The URL of the discussion comment",
+				"type": "string"
 			}
 		}
 	},


### PR DESCRIPTION
# Summary of the issue

When add-ons are submitted to the store, comments for add-ons reviews in GitHub discussions are been created, and the corresponding URL is being added to add-on metadata.

# Development strategy

The reviewUrl key has been added to the json schema.

# Testing performed

Run tox. Unfortunately, I'm not able to use runvalidate on my locale machine

Note: Instructions may need to be updated in the readme, @seanbudd.
