### PR TITLE
Write errors to log if generateJsonFile fails

### DIFF
--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -213,18 +213,30 @@ def main():
 				errorFile.write(f"Validation Errors:\n{manifest.errors}")
 		raise ValueError(f"Invalid manifest file: {manifest.errors}")
 
-	generateJsonFile(
-		manifest=manifest,
-		addonPath=args.file,
-		parentDir=args.parentDir,
-		channel=args.channel,
-		publisher=args.publisher,
-		sourceUrl=args.sourceUrl,
-		url=args.url,
-		licenseName=args.licenseName,
-		# Convert the case --licUrl='' to --licUrl=None
-		licenseUrl=args.licenseUrl if args.licenseUrl else None,
-	)
+	try:
+		generateJsonFile(
+			manifest=manifest,
+			addonPath=args.file,
+			parentDir=args.parentDir,
+			channel=args.channel,
+			publisher=args.publisher,
+			sourceUrl=args.sourceUrl,
+			url=args.url,
+			licenseName=args.licenseName,
+			# Convert the case --licUrl='' to --licUrl=None
+			licenseUrl=args.licenseUrl if args.licenseUrl else None,
+		)
+	except Exception as e:
+		if manifest.errors:
+			if errorFilePath:
+				with open(errorFilePath, "w") as errorFile:
+					errorFile.write(f"Validation Errors:\n{manifest.errors}")
+			raise ValueError(f"Invalid manifest file: {manifest.errors}")
+		else:
+			if errorFilePath:
+				with open(errorFilePath, "w") as errorFile:
+					errorFile.write(f"Validation Errors:\n{e}")
+			raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently if an add-on manifest is invalid, and the submission process fails to create a json file for the add-on store, the submission fails with no relevant errors reported to the user.

Example:
- https://github.com/nvaccess/addon-datastore/actions/runs/7839789843/job/21393388987
- https://github.com/nvaccess/addon-datastore/issues/2470