### PR TITLE
Add timestamp to jsonschema

### DIFF
--- a/_tests/test_createJson.py
+++ b/_tests/test_createJson.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2022 Noelia Ruiz Martínez, NV Access Limited
+# Copyright (C) 2022-2024 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/_tests/test_createJson.py
+++ b/_tests/test_createJson.py
@@ -79,6 +79,7 @@ class IntegrationTestCreateJson(unittest.TestCase):
 			del expectedJson["sha256-comment"]  # remove explanatory comment
 		with open(actualJsonPath) as actualFile:
 			actualJson = json.load(actualFile)
+			del actualJson["submissionTime"]  # remove submission time
 
 		self.assertDictEqual(actualJson, expectedJson)
 

--- a/_validate/addonVersion_schema.json
+++ b/_validate/addonVersion_schema.json
@@ -36,7 +36,7 @@
 				}
 			],
 			"reviewUrl": "https://github.com/nvaccess/addon-datastore/discussions/1942#discussioncomment-7453248",
-			"timestamp": 1723523492363.093
+			"submissionTime": 1723523492363.093
 		}
 	],
 	"title": "Root",

--- a/_validate/addonVersion_schema.json
+++ b/_validate/addonVersion_schema.json
@@ -36,7 +36,7 @@
 				}
 			],
 			"reviewUrl": "https://github.com/nvaccess/addon-datastore/discussions/1942#discussioncomment-7453248",
-			"submissionTime": 1723523492363.093
+			"submissionTime": 1723523492363
 		}
 	],
 	"title": "Root",
@@ -271,7 +271,7 @@
 				"default": 0,
 				"description": "Timestamp in milliseconds, corresponding to the submission time of the add-on",
 				"examples": [
-					1723523492363.093
+					1723523492363
 				],
 				"title": "Submission time",
 				"type": "number"

--- a/_validate/addonVersion_schema.json
+++ b/_validate/addonVersion_schema.json
@@ -266,14 +266,14 @@
 				"title": "Discussion comment URL",
 				"type": "string"
 			},
-			"timestamp": {
-				"$id": "#/properties/timestamp",
+			"submissionTime": {
+				"$id": "#/properties/submissionTime",
 				"default": 0,
-				"description": "Timestamp in milliseconds, corresponding to the publication date of the add-on",
+				"description": "Timestamp in milliseconds, corresponding to the submission time of the add-on",
 				"examples": [
 					1723523492363.093
 				],
-				"title": "Timestamp in milliseconds",
+				"title": "Submission time",
 				"type": "number"
 			},
 			"vtScanUrl": {

--- a/_validate/addonVersion_schema.json
+++ b/_validate/addonVersion_schema.json
@@ -35,9 +35,9 @@
 					"description": "erleichtert das Durchführen von xyz"
 				}
 			],
-			"reviewUrl": "https://github.com/nvaccess/addon-datastore/discussions/1942#discussioncomment-7453248"
+			"reviewUrl": "https://github.com/nvaccess/addon-datastore/discussions/1942#discussioncomment-7453248",
+			"timestamp": 1723523492363.093
 		}
-
 	],
 	"title": "Root",
 	"type": "object",
@@ -265,6 +265,16 @@
 				],
 				"title": "Discussion comment URL",
 				"type": "string"
+			},
+			"timestamp": {
+				"$id": "#/properties/timestamp",
+				"default": 0,
+				"description": "Timestamp in milliseconds, corresponding to the publication date of the add-on",
+				"examples": [
+					1723523492363.093
+				],
+				"title": "Timestamp in milliseconds",
+				"type": "number"
 			},
 			"vtScanUrl": {
 				"$id": "#/properties/vtScanUrl",

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2022-2023 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+import time
 import dataclasses
 import json
 import argparse
@@ -29,6 +30,10 @@ def getSha256(addonPath: str) -> str:
 	with open(addonPath, "rb") as f:
 		sha256Addon = sha256.sha256_checksum(f)
 	return sha256Addon
+
+
+def getCurrentTime() -> float:
+	return time.time() * 1000  # Milliseconds
 
 
 def generateJsonFile(
@@ -121,6 +126,7 @@ def _createDictMatchingJsonSchema(
 		addonData["homepage"] = homepage
 	if licenseUrl:
 		addonData["licenseURL"] = licenseUrl
+	addonData["submissionTime"] = getCurrentTime()
 
 	addonData["translations"] = []
 	for langCode, manifest in getAddonManifestLocalizations(manifest):

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2022-2024 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
 import time
 import dataclasses
 import json
@@ -32,8 +33,8 @@ def getSha256(addonPath: str) -> str:
 	return sha256Addon
 
 
-def getCurrentTime() -> float:
-	return time.time() * 1000  # Milliseconds
+def getCurrentTime() -> int:
+	return int(time.gmtime() * 1000)  # Milliseconds
 
 
 def generateJsonFile(

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2022-2023 Noelia Ruiz Martínez, NV Access Limited
+# Copyright (C) 2022-2024 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 import time

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -4,7 +4,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-import time
+from time import gmtime, mktime
 import dataclasses
 import json
 import argparse
@@ -34,7 +34,7 @@ def getSha256(addonPath: str) -> str:
 
 
 def getCurrentTime() -> int:
-	return int(time.gmtime() * 1000)  # Milliseconds
+	return int(mktime(gmtime()) * 1000)  # Milliseconds
 
 
 def generateJsonFile(


### PR DESCRIPTION
### Summary of the issue

Add-on metadata may accept a timestamp, to sort add-ons or perform other queries.

### Development approach

- Update the json schema to accept an optional "submissionTime", corresponding to a timestamp. We use milliseconds instead of seconds, in case similar values are added in the future, for a better comparison.
- When creating a json file, the current time will be assigned to submissionTime.
- Updated tests, removing the submissionTime before comparing actual and expected json files.