### PR TITLE
Use utf-8 for validation

### DIFF
--- a/_tests/test_createJson.py
+++ b/_tests/test_createJson.py
@@ -32,7 +32,7 @@ OUTPUT_DATA_PATH = os.path.join(SOURCE_DIR, '_tests', 'testOutput')
 
 
 def getAddonManifest():
-	with open(MANIFEST_FILE) as f:
+	with open(MANIFEST_FILE, encoding="utf-8") as f:
 		manifest = addonManifest.AddonManifest(f)
 	return manifest
 
@@ -74,10 +74,10 @@ class IntegrationTestCreateJson(unittest.TestCase):
 	def _assertJsonFilesEqual(self, actualJsonPath: str, expectedJsonPath: str):
 
 		# Not equal, how are they different?
-		with open(VALID_JSON) as expectedFile:
+		with open(VALID_JSON, encoding="utf-8") as expectedFile:
 			expectedJson = json.load(expectedFile)
 			del expectedJson["sha256-comment"]  # remove explanatory comment
-		with open(actualJsonPath) as actualFile:
+		with open(actualJsonPath, encoding="utf-8") as actualFile:
 			actualJson = json.load(actualFile)
 			del actualJson["submissionTime"]  # remove submission time
 

--- a/_tests/test_validate.py
+++ b/_tests/test_validate.py
@@ -26,13 +26,13 @@ VERSIONS_FILE = os.path.join(TEST_DATA_PATH, 'nvdaAPIVersions.json')
 
 
 def getValidAddonSubmission() -> validate.JsonObjT:
-	with open(VALID_SUBMISSION_JSON_FILE) as f:
+	with open(VALID_SUBMISSION_JSON_FILE, encoding="utf-8") as f:
 		submission = json.load(f)
 	return submission
 
 
 def getAddonManifest():
-	with open(MANIFEST_FILE) as f:
+	with open(MANIFEST_FILE, encoding="utf-8") as f:
 		manifest = addonManifest.AddonManifest(f)
 	return manifest
 

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -61,7 +61,7 @@ def generateJsonFile(
 
 	filePath = buildOutputFilePath(data, parentDir)
 
-	with open(filePath, "wt") as f:
+	with open(filePath, "wt", encoding="utf-8") as f:
 		json.dump(data, f, indent="\t")
 	print(f"Wrote json file: {filePath}")
 

--- a/_validate/regenerateTranslations.py
+++ b/_validate/regenerateTranslations.py
@@ -22,7 +22,7 @@ del sys.path[-1]
 
 
 def regenerateJsonFile(filePath: str, errorFilePath: Optional[str]) -> None:
-	with open(filePath) as f:
+	with open(filePath, encoding="utf-8") as f:
 		addonData = json.load(f)
 	if addonData.get("legacy"):
 		return
@@ -44,7 +44,7 @@ def regenerateJsonFile(filePath: str, errorFilePath: Optional[str]) -> None:
 			}
 		)
 	
-	with open(filePath, "wt") as f:
+	with open(filePath, "wt", encoding="utf-8") as f:
 		json.dump(addonData, f, indent="\t")
 	print(f"Wrote json file: {filePath}")
 

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -42,7 +42,7 @@ def getAddonMetadata(filename: str) -> JsonObjT:
 	"""Loads addon submission metadata json file and returns as object.
 	Raises if the metadata does not conform to the schema.
 	"""
-	with open(filename) as f:
+	with open(filename, encoding="utf-8") as f:
 		data: JsonObjT = json.load(f)
 	_validateJson(data)
 	return data
@@ -51,7 +51,7 @@ def getAddonMetadata(filename: str) -> JsonObjT:
 def getExistingVersions(verFilename: str) -> List[str]:
 	"""Loads API versions file and returns list of versions formatted as strings.
 	"""
-	with open(verFilename) as f:
+	with open(verFilename, encoding="utf-8") as f:
 		data: List[JsonObjT] = json.load(f)
 	return [_formatVersionString(version["apiVer"].values()) for version in data]
 
@@ -59,7 +59,7 @@ def getExistingVersions(verFilename: str) -> List[str]:
 def getExistingStableVersions(verFilename: str) -> List[str]:
 	"""Loads API versions file and returns list of stable versions formatted as strings.
 	"""
-	with open(verFilename) as f:
+	with open(verFilename, encoding="utf-8") as f:
 		data: List[JsonObjT] = json.load(f)
 	return [
 		_formatVersionString(version["apiVer"].values())
@@ -72,7 +72,7 @@ def _validateJson(data: JsonObjT) -> None:
 	""" Ensure that the loaded metadata conforms to the schema.
 	Raise error if not
 	"""
-	with open(JSON_SCHEMA) as f:
+	with open(JSON_SCHEMA, encoding="utf-8") as f:
 		schema = json.load(f)
 	try:
 		validate(instance=data, schema=schema)


### PR DESCRIPTION
Successful run: https://github.com/nvaccess/addon-datastore/actions/runs/10987336774
Example failure of utf-8 files not being read properly: https://github.com/nvaccess/addon-datastore/actions/runs/10986773906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated file reading and writing operations across multiple modules to ensure UTF-8 encoding is used, improving compatibility with non-ASCII characters in JSON files.
	- Enhanced the handling of JSON data in various functions, ensuring accurate interpretation and processing.

These changes enhance the robustness of file operations within the application, particularly for internationalization and diverse character sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->