### PR TITLE
Improve add-on submission error reporting

### DIFF
--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2022-2024 Noelia Ruiz Martínez, NV Access Limited
+# Copyright (C) 2022-2025 Noelia Ruiz Martínez, NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -92,8 +92,7 @@ def _createDictMatchingJsonSchema(
 	try:
 		addonVersionNumber = MajorMinorPatch.getFromStr(manifest["version"])
 	except ValueError:
-		manifest._errors = f"Manifest version invalid {addonVersionNumber}"
-		raise
+		raise ValueError(f"Manifest version invalid {addonVersionNumber}")
 
 	try:
 		addonData = {
@@ -116,8 +115,7 @@ def _createDictMatchingJsonSchema(
 			"license": licenseName,
 		}
 	except KeyError as e:
-		manifest._errors = f"Manifest missing required key '{e.args[0]}'."
-		raise
+		raise KeyError(f"Manifest missing required key '{e.args[0]}'.")
 
 	# Add optional fields
 	homepage = manifest.get("url")
@@ -140,8 +138,7 @@ def _createDictMatchingJsonSchema(
 				}
 			)
 		except KeyError as e:
-			manifest._errors = f"Translation for {langCode} missing required key '{e.args[0]}'."
-			raise
+			raise KeyError(f"Translation for {langCode} missing required key '{e.args[0]}'.")
 
 	return addonData
 

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -91,8 +91,8 @@ def _createDictMatchingJsonSchema(
 	"""Refer to _validate/addonVersion_schema.json"""
 	try:
 		addonVersionNumber = MajorMinorPatch.getFromStr(manifest["version"])
-	except ValueError:
-		raise ValueError(f"Manifest version invalid {addonVersionNumber}")
+	except ValueError as e:
+		raise ValueError(f"Manifest version invalid {addonVersionNumber}") from e
 
 	try:
 		addonData = {
@@ -115,7 +115,7 @@ def _createDictMatchingJsonSchema(
 			"license": licenseName,
 		}
 	except KeyError as e:
-		raise KeyError(f"Manifest missing required key '{e.args[0]}'.")
+		raise KeyError(f"Manifest missing required key '{e.args[0]}'.") from e
 
 	# Add optional fields
 	homepage = manifest.get("url")
@@ -138,7 +138,7 @@ def _createDictMatchingJsonSchema(
 				}
 			)
 		except KeyError as e:
-			raise KeyError(f"Translation for {langCode} missing required key '{e.args[0]}'.")
+			raise KeyError(f"Translation for {langCode} missing required key '{e.args[0]}'.") from e
 
 	return addonData
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ flake8==3.9.2
 flake8-tabs==2.2.2
 
 # Requirements for validate
-git+https://github.com/DiffSK/configobj@3e2f4cc#egg=configobj
-jsonschema==3.1
+configobj @ git+https://github.com/DiffSK/configobj@8be54629ee7c26acb5c865b74c76284e80f3aa31#egg=configobj
+jsonschema==4.23.0
 


### PR DESCRIPTION
When exceptions are raised in submission, the exception itself is reported to the submitter, not the `manifest._errors` contents.

This creates a less helpful comment e.g.:
https://github.com/nvaccess/addon-datastore/issues/5198#issuecomment-2752613897

Tested by running createJson.py locally

Also updated dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved error handling to ensure more consistent and clear error messages during data processing.
- **Chore**
  - Updated key dependencies to incorporate the latest stability and performance improvements, including `configobj` and `jsonschema`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->