### PR TITLE
Validate add-on ID format

### DIFF
--- a/_tests/test_validate.py
+++ b/_tests/test_validate.py
@@ -282,10 +282,12 @@ class Validate_checkAddonId(unittest.TestCase):
 			errors
 		)
 
-	def test_invalidAddonIdFormat_spaces(self):
+	@patch('os.path.basename', return_value="invalid addon id")
+	def test_invalidAddonIdFormat_spaces(self, mock_basename):
 		""" Error when submission does not include correct addonId format
 		"""
 		self.submissionData['addonId'] = "invalid addon id"
+		self.manifest['name'] = "invalid addon id"
 		errors = list(
 			validate.checkAddonId(self.manifest, VALID_SUBMISSION_JSON_FILE, self.submissionData)
 		)
@@ -294,15 +296,18 @@ class Validate_checkAddonId(unittest.TestCase):
 			[  # expected errors
 				"Submission data 'addonId' field does not match the expected format:"
 				" must start and end with a letter, and contain only letters,"
-				" numbers, and hyphens. invalid addon id"
+				" numbers, and hyphens. "
+				"ID: invalid addon id"
 			],
 			errors
 		)
 
-	def test_invalidAddonIdFormat_invalidStartChar(self):
+	@patch('os.path.basename', return_value="1invalid-addon-id")
+	def test_invalidAddonIdFormat_invalidStartChar(self, mock_basename):
 		""" Error when submission does not include correct addonId format
 		"""
 		self.submissionData['addonId'] = "1invalid-addon-id"
+		self.manifest['name'] = "1invalid-addon-id"
 		errors = list(
 			validate.checkAddonId(self.manifest, VALID_SUBMISSION_JSON_FILE, self.submissionData)
 		)
@@ -311,7 +316,8 @@ class Validate_checkAddonId(unittest.TestCase):
 			[  # expected errors
 				"Submission data 'addonId' field does not match the expected format:"
 				" must start and end with a letter, and contain only letters,"
-				" numbers, and hyphens. invalid addon id"
+				" numbers, and hyphens. "
+				"ID: 1invalid-addon-id"
 			],
 			errors
 		)

--- a/_tests/test_validate.py
+++ b/_tests/test_validate.py
@@ -282,6 +282,40 @@ class Validate_checkAddonId(unittest.TestCase):
 			errors
 		)
 
+	def test_invalidAddonIdFormat_spaces(self):
+		""" Error when submission does not include correct addonId format
+		"""
+		self.submissionData['addonId'] = "invalid addon id"
+		errors = list(
+			validate.checkAddonId(self.manifest, VALID_SUBMISSION_JSON_FILE, self.submissionData)
+		)
+
+		self.assertEqual(
+			[  # expected errors
+				"Submission data 'addonId' field does not match the expected format:"
+				" must start and end with a letter, and contain only letters,"
+				" numbers, and hyphens. invalid addon id"
+			],
+			errors
+		)
+
+	def test_invalidAddonIdFormat_invalidStartChar(self):
+		""" Error when submission does not include correct addonId format
+		"""
+		self.submissionData['addonId'] = "1invalid-addon-id"
+		errors = list(
+			validate.checkAddonId(self.manifest, VALID_SUBMISSION_JSON_FILE, self.submissionData)
+		)
+
+		self.assertEqual(
+			[  # expected errors
+				"Submission data 'addonId' field does not match the expected format:"
+				" must start and end with a letter, and contain only letters,"
+				" numbers, and hyphens. invalid addon id"
+			],
+			errors
+		)
+
 
 @dataclass
 class VersionNumber:

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -180,6 +180,13 @@ def checkAddonId(
 			"Submission data 'addonId' field does not match 'name' field in addon manifest:"
 			f" {expectedName} vs {submission['addonId']}"
 		)
+	if not re.match(r"^[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9]$", expectedName):
+		yield (
+			"Submission data 'addonId' field does not match the expected format:"
+			" must start and end with a letter, and contain only letters,"
+			" numbers, and hyphens."
+			f" {submission['addonId']}"
+		)
 
 
 VERSION_PARSE = re.compile(r"^(\d+)(?:$|(?:\.(\d+)$)|(?:\.(\d+)\.(\d+)$))")

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -184,8 +184,8 @@ def checkAddonId(
 		yield (
 			"Submission data 'addonId' field does not match the expected format:"
 			" must start and end with a letter, and contain only letters,"
-			" numbers, and hyphens."
-			f" {submission['addonId']}"
+			" numbers, and hyphens. "
+			f"ID: {submission['addonId']}"
 		)
 
 


### PR DESCRIPTION
add-ons have been submitted to the store with invalid formats for add-on IDs such as containing spaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved validation for add-on identifiers to ensure they start and end with a letter and contain only letters, numbers, and hyphens. Users will now receive clearer error messages if the format requirements are not met.

* **Tests**
  * Added tests to verify that invalid add-on identifier formats are correctly detected and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->