### PR TITLE
add support for underscores in addonIds

### DIFF
--- a/_tests/test_validate.py
+++ b/_tests/test_validate.py
@@ -224,6 +224,22 @@ class Validate_checkAddonId(unittest.TestCase):
 			errors
 		)
 
+	@patch('os.path.basename', return_value="valid1-Addon_id")
+	def test_valid_withSymbols(self, mock_basename):
+		""" Error when submission does not include correct addonId format
+		"""
+		self.submissionData['addonId'] = "valid1-Addon_id"
+		self.manifest['name'] = "valid1-Addon_id"
+		errors = list(
+			validate.checkAddonId(self.manifest, VALID_SUBMISSION_JSON_FILE, self.submissionData)
+		)
+
+		self.assertEqual(
+			[  # expected errors
+			],
+			errors
+		)
+
 	def test_invalidPath(self):
 		""" Error when submission path does not include correct addon ID
 		"""
@@ -296,7 +312,7 @@ class Validate_checkAddonId(unittest.TestCase):
 			[  # expected errors
 				"Submission data 'addonId' field does not match the expected format:"
 				" must start and end with a letter, and contain only letters,"
-				" numbers, and hyphens. "
+				" numbers, underscores, and hyphens. "
 				"ID: invalid addon id"
 			],
 			errors
@@ -316,7 +332,7 @@ class Validate_checkAddonId(unittest.TestCase):
 			[  # expected errors
 				"Submission data 'addonId' field does not match the expected format:"
 				" must start and end with a letter, and contain only letters,"
-				" numbers, and hyphens. "
+				" numbers, underscores, and hyphens. "
 				"ID: 1invalid-addon-id"
 			],
 			errors

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -180,11 +180,11 @@ def checkAddonId(
 			"Submission data 'addonId' field does not match 'name' field in addon manifest:"
 			f" {expectedName} vs {submission['addonId']}"
 		)
-	if not re.match(r"^[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9]$", expectedName):
+	if not re.match(r"^[A-Za-z][A-Za-z0-9\-_]*[A-Za-z0-9]$", expectedName):
 		yield (
 			"Submission data 'addonId' field does not match the expected format:"
 			" must start and end with a letter, and contain only letters,"
-			" numbers, and hyphens. "
+			" numbers, underscores, and hyphens. "
 			f"ID: {submission['addonId']}"
 		)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation rules to allow underscores in add-on IDs, in addition to letters, numbers, and hyphens.
  * Improved error messages to reflect the inclusion of underscores as valid characters.

* **Tests**
  * Added a new test to confirm that add-on IDs with underscores are accepted.
  * Updated existing tests and error messages to align with the new validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->