### PR TITLE
Raise error if no files are found

### DIFF
--- a/.github/workflows/testCode.yaml
+++ b/.github/workflows/testCode.yaml
@@ -42,4 +42,4 @@ jobs:
     - name: Generate json file
       shell: cmd
       # E2E: test to check the script can be run
-      run: .\runcreatejson.bat -f fake.nvda-addon --dir .\tests\testData --channel=stable --publisher=fakepublisher --sourceUrl=https://github.com/fake/ --url=https://github.com/fake.nvda-addon --licName="GPL v2" --licUrl="https://www.gnu.org/licenses/gpl-2.0.html"
+      run: .\runcreatejson.bat -f tests/testData/fake.nvda-addon --dir tests/testOutput/test_runcreatejson --channel=stable --publisher=fakepublisher --sourceUrl=https://github.com/fake/ --url=https://github.com/fake.nvda-addon --licName="GPL v2" --licUrl="https://www.gnu.org/licenses/gpl-2.0.html"

--- a/.github/workflows/testCode.yaml
+++ b/.github/workflows/testCode.yaml
@@ -34,11 +34,11 @@ jobs:
       shell: cmd
       # E2E: test to check the script can be run, no need to actually test the file.
       # The internal checks are covered with unit tests.
-      run: .\runvalidate.bat --dry-run _test/testData/addons/fake/13.0.json tests\testData\nvdaAPIVersions.json
+      run: .\runvalidate.bat --dry-run tests/testData/addons/fake/13.0.json tests/testData/nvdaAPIVersions.json
     - name: Get sha256
       shell: cmd
       # E2E: test to check the script can be run
-      run: .\runsha.bat tests\testData\fake.nvda-addon
+      run: .\runsha.bat tests/testData/fake.nvda-addon
     - name: Generate json file
       shell: cmd
       # E2E: test to check the script can be run

--- a/.github/workflows/testCode.yaml
+++ b/.github/workflows/testCode.yaml
@@ -34,7 +34,7 @@ jobs:
       shell: cmd
       # E2E: test to check the script can be run, no need to actually test the file.
       # The internal checks are covered with unit tests.
-      run: .\runvalidate.bat --dry-run tests/testData/addons/fake/13.0.json tests/testData/nvdaAPIVersions.json
+      run: .\runvalidate.bat --dry-run tests/testData/addons/fake/13.0.0.json tests/testData/nvdaAPIVersions.json
     - name: Get sha256
       shell: cmd
       # E2E: test to check the script can be run

--- a/.github/workflows/testCode.yaml
+++ b/.github/workflows/testCode.yaml
@@ -42,4 +42,4 @@ jobs:
     - name: Generate json file
       shell: cmd
       # E2E: test to check the script can be run
-      run: .\runcreatejson.bat -f tests\testData\fake.nvda-addon --dir tests\testOutput\test_runcreatejson --channel=stable --publisher=fakepublisher --sourceUrl=https://github.com/fake/ --url=https://github.com/fake.nvda-addon --licName="GPL v2" --licUrl="https://www.gnu.org/licenses/gpl-2.0.html"
+      run: .\runcreatejson.bat -f fake.nvda-addon --dir .\tests\testData --channel=stable --publisher=fakepublisher --sourceUrl=https://github.com/fake/ --url=https://github.com/fake.nvda-addon --licName="GPL v2" --licUrl="https://www.gnu.org/licenses/gpl-2.0.html"

--- a/_validate/validate.py
+++ b/_validate/validate.py
@@ -380,6 +380,9 @@ def main():
 	if errorOutputFile and os.path.exists(errorOutputFile):
 		os.remove(errorOutputFile)
 
+	if not addonFiles:
+		raise ValueError(f"No files found matching: {args.filePathGlob}")
+
 	if not args.dry_run:
 		anyErrors = False
 		for filename in addonFiles:


### PR DESCRIPTION
Passing in an invalid path leads validation to unexpectedly pass.
This is because when globbing the path, no files are found, meaning validation occurs against no files.
This can be quite misleading for developers, as it is unclear why passing in what seems like a proper file path with validation errors yields no validation errors. See https://github.com/nvaccess/addon-datastore/issues/6712 for context