### PR TITLE
Remove items whose value is None before dumping to JSON

### DIFF
--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -72,7 +72,18 @@ def generateJsonFile(
 	filePath = buildOutputFilePath(data, parentDir)
 
 	with open(filePath, "wt", encoding="utf-8") as f:
-		json.dump(dataclasses.asdict(data), f, indent="\t", ensure_ascii=False)
+		json.dump(
+			dataclasses.asdict(
+				data,
+				# The JSON schema does not permit null values, but does contain optional keys.
+				# # We have already ensured that all required keys are present in the metadata,
+				# So we can safely delete all keys whose value is None as optional.
+				dict_factory=lambda args: dict(filter(lambda item: item[1] is not None, args)),
+			),
+			f,
+			indent="\t",
+			ensure_ascii=False,
+		)
 	print(f"Wrote json file: {filePath}")
 
 

--- a/_validate/createJson.py
+++ b/_validate/createJson.py
@@ -76,7 +76,7 @@ def generateJsonFile(
 			dataclasses.asdict(
 				data,
 				# The JSON schema does not permit null values, but does contain optional keys.
-				# # We have already ensured that all required keys are present in the metadata,
+				# We have already ensured that all required keys are present in the metadata,
 				# So we can safely delete all keys whose value is None as optional.
 				dict_factory=lambda args: dict(filter(lambda item: item[1] is not None, args)),
 			),


### PR DESCRIPTION
Some add-on submissions, [such as this one](https://github.com/nvaccess/addon-datastore/actions/runs/18804944770) are failing.

The problem appears to be that optional values in the JSON metadata are being given a value of `null`, rather than omitted. Since `null` is a value, and the datatype for these keys is string, the validation fails.

Thus, remove any `None` values from the add-on metadata before dumping to JSON. I believe this is safe, as we have already validated that all required keys are present, so any `None`s on the dataclass are optional keys that haven't been provided. 
